### PR TITLE
Solver binary debug tools

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,11 @@ __pycache__/
 *.py[cod]
 *$py.class
 
+# Vim
+
+*.swp
+*.swo
+
 # C extensions
 *.so
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,17 @@
+FROM jupyter/minimal-notebook:latest
+
+USER root
+
+RUN apt-get update && apt-get install -y libgl1-mesa-glx gdb
+
+RUN apt-get -o Dpkg::Options::="--force-confmiss" install --reinstall netbase
+
+USER jovyan
+
+RUN python3 -m pip install gdbgui matplotlib
+
+WORKDIR /home/jovyan
+
+COPY --chown=jovyan:users ./requirements.txt ./requirements.txt
+
+RUN pip install -r ./requirements.txt

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ This package is intended to replace the PyURDME software https://github.com/pyur
 
 ### Docker environment
 
-You can use Docker to create a repeatable environment for developing and debugging spatialpy. The supplied Dockerfile starts a jupyter server with spatialpy dependencies installed.
+You can use Docker to create a repeatable environment for developing and debugging SpatialPy. The supplied Dockerfile starts a jupyter server with SpatialPy dependencies installed.
 
 If you have Docker Compose: `docker-compose build && docker-compose up`
 
@@ -19,8 +19,9 @@ docker build -t spatialpy:latest .
 docker run -v ./:/home/jovyan/spatialpy -v ./tmp:/tmp -p 8888:8888 -p 5000:5000
 ```
 
-The spatialpy repo is mounted into /home/jovyan so you can import it directly in the usual way supplied to examples. 
-Any changes you make in your local spatialpy codebase are reflected in the docker container. Note that you DO NOT need to restart the docker container or even re-import spatialpy to see source changes take effect in jupyter notebooks.
+The SpatialPy repo is mounted into /home/jovyan so you can import it in the usual way for development (see examples).
+
+Any changes you make to your local codebase are reflected in the docker container. Note that you DO NOT need to restart the docker container or even re-import spatialpy to see source changes take effect in jupyter notebooks.
 
 The `/tmp` directory is also mounted for easy access to build and result directories.
 
@@ -28,7 +29,7 @@ The `/tmp` directory is also mounted for easy access to build and result directo
 
 In order to compile the solver binary for use by the debugger, run `solver.compile()` with `debug=True`. This will inject the `-g` flag into the `gcc` command that compiles the solver, enabling gdb debug information.
 
-You can run `solver.run_debugger()` anytime after you instantiate a solver in Python to start up a new session of gdbgui. After that the debugger will be available at http://127.0.0.1:5000.
+You can invoke `solver.run_debugger()` anytime after you instantiate a solver in Python to start up a new session of gdbgui. The debugger will be available at http://127.0.0.1:5000.
 
 
 ### Profiling

--- a/README.md
+++ b/README.md
@@ -6,6 +6,35 @@ SpatialPy is a Python 3 package for simulation of spatial deterministic/stochast
 
 This package is intended to replace the PyURDME software https://github.com/pyurdme/pyurdme and will feature both a NSM solver for RDME simulation on static domains and a sSSA-SDPD particle based fluid dynamics solver as described in the publication "A hybrid smoothed dissipative particle dynamics (SDPD) spatial stochastic simulation algorithm (sSSA) for advection–diffusion–reaction problems" by Drawert, Jacob, Li, Yi, Petzold https://www.sciencedirect.com/science/article/pii/S0021999118307101
 
+### Docker environment
+
+You can use Docker to create a repeatable environment for developing and debugging spatialpy. The supplied Dockerfile starts a jupyter server with spatialpy dependencies installed.
+
+If you have Docker Compose: `docker-compose build && docker-compose up`
+
+Otherwise:
+
+```bash
+docker build -t spatialpy:latest .
+docker run -v ./:/home/jovyan/spatialpy -v ./tmp:/tmp -p 8888:8888 -p 5000:5000
+```
+
+The spatialpy repo is mounted into /home/jovyan so you can import it directly in the usual way supplied to examples. 
+Any changes you make in your local spatialpy codebase are reflected in the docker container. Note that you DO NOT need to restart the docker container or even re-import spatialpy to see source changes take effect in jupyter notebooks.
+
+The `/tmp` directory is also mounted for easy access to build and result directories.
+
+### Debugging
+
+In order to compile the solver binary for use by the debugger, run `solver.compile()` with `debug=True`. This will inject the `-g` flag into the `gcc` command that compiles the solver, enabling gdb debug information.
+
+You can run `solver.run_debugger()` anytime after you instantiate a solver in Python to start up a new session of gdbgui. After that the debugger will be available at http://127.0.0.1:5000.
+
+
+### Profiling
+
+To enable profiling, both `solver.compile()` and `solver.run()` need to be invoked with `profile=True`. If you don't run `solver.compile()` explicitly, invoking `solver.run()` with `profile=True` will run `compile()` correctly for you.
+
 <table><tr><td><b>
 <img width="20%" align="right" src="https://raw.githubusercontent.com/GillesPy2/GillesPy2/develop/.graphics/stochss-logo.png">
 <a href="https://docs.google.com/forms/d/12tAH4f8CJ-3F-lK44Q9uQHFio_mGoK0oY829q5lD7i4/viewform">PLEASE REGISTER AS A USER</a>, so that we can prove SpatialPy has many users when we seek funding to support development. SpatialPy is part of the <a href="http://www.stochss.org">StochSS</a> project.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,13 @@
+version: "3.1"
+
+services:
+  notebook:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    volumes:
+      - "./:/home/jovyan/spatialpy"
+      - "./tmp:/tmp"
+    ports:
+      - "8888:8888"
+      - "5000:5000"

--- a/spatialpy/Model.py
+++ b/spatialpy/Model.py
@@ -55,7 +55,7 @@ class Model():
         self.output_freq = None
 
 
-    def run(self, number_of_trajectories=1, seed=None, number_of_threads=None, debug_level=0):
+    def run(self, number_of_trajectories=1, seed=None, number_of_threads=None, debug_level=0, debug=False, profile=False):
         """ Simulate the model.
         Args:
             number_of_trajectories: How many trajectories should be run.
@@ -68,7 +68,7 @@ class Model():
 
         sol = Solver(self, debug_level=debug_level)
 
-        return sol.run(number_of_trajectories=number_of_trajectories, seed=seed, number_of_threads=number_of_threads)
+        return sol.run(number_of_trajectories=number_of_trajectories, seed=seed, number_of_threads=number_of_threads, debug=debug, profile=profile)
 
 
     def set_timesteps(self, step_size, num_steps):

--- a/spatialpy/ssa_sdpd-c-simulation-engine/build/Makefile
+++ b/spatialpy/ssa_sdpd-c-simulation-engine/build/Makefile
@@ -13,13 +13,13 @@ OBJ = linked_list.o particle.o simulate.o count_cores.o output.o simulate_rdme.o
 all: ssa_sdpd
 
 main.o:
-	$(CC) -c -o main.o $(MODEL) $(INCDIRPARAMS) $(CFLAGS) $(DSFMTFLAGS)
+	$(CC) -c $(GPROFFLAG) $(GDB_FLAG) -o main.o $(MODEL) $(INCDIRPARAMS) $(CFLAGS) $(DSFMTFLAGS)
 
 dSFMT.o:
-	$(CC) -c -o dSFMT.o $(ROOTINC)/external/dSFMT/dSFMT.c $(INCDIRPARAMS) $(CFLAGS) $(DSFMTFLAGS)
+	$(CC) -c $(GPROFFLAG) $(GDB_FLAG) -o dSFMT.o $(ROOTINC)/external/dSFMT/dSFMT.c $(INCDIRPARAMS) $(CFLAGS) $(DSFMTFLAGS)
 
 %.o: $(ROOT)/src/%.c
-	$(CC) -c -o $@ "$<" $(INCDIRPARAMS) $(CFLAGS) $(DSFMTFLAGS)
+	$(CC) -c $(GPROFFLAG) $(GDB_FLAG) -o $@ "$<" $(INCDIRPARAMS) $(CFLAGS) $(DSFMTFLAGS)
 
 ssa_sdpd: main.o dSFMT.o $(OBJ)
-	$(CC)  -o ssa_sdpd $(OBJ)  main.o dSFMT.o $(LFLAGS)
+	$(CC) $(GPROFFLAG) $(GDB_FLAG) -o ssa_sdpd $(OBJ)  main.o dSFMT.o $(LFLAGS)


### PR DESCRIPTION
Add debugging and profiling tools for C binaries.

Adds support for spawning a gdbgui debugger as well as the ability
to run profiling on solver binaries with gprof.

To enable debugging, run `solver.compile` with `debug=True`. This
adds the `-g` flag into the `gcc` commands that do the compilation,
enabling debugging information to be injected into the resulting
binaries.

To start the debugger, run `solver.run_debugger()`. This will open
a new gdbgui session at `http://127.0.0.1:5000`. Use the result of
the compile() statement to get the build directory of the compiled
binary and place it in the path in gdbgui, followed by the name
of the executable, currently `ssa_sdpd`. For example, if your build
directory is `/tmp/spatialpy_build_0q9u0_lg` then you would put the
path `/tmp/spatialpy_build_0q9u0_lg/ssa_sdpd` into the path field
in gdbgui and then click "Load Binary."

If your solver has not been compiled and you rely on run() to
compile the binary implicitly, passing `debug=True` to run() will
run `compile()` with `debug=True`.

To enable profiling, you must invoke compile() and/or run() with
`profile=True`. The binary must have been compiled with `profile=True`.
If you invoke `run()` with `profile=True` on a binary that was
compiled with `profile=False` it will not work! Anyway, once the run
completes the gprof report for each trajectory will be printed.

Problems / Todos:

- Turning off the debugger. Here are the things that I've tried that do not work:
  - `proc.send_signal(signal.SIGINT)`
  - `proc.terminate()`
  - `proc.kill()`