### PR TITLE
Fix Memory Leak

### DIFF
--- a/spatialpy/ssa_sdpd-c-simulation-engine/include/particle.hpp
+++ b/spatialpy/ssa_sdpd-c-simulation-engine/include/particle.hpp
@@ -41,7 +41,9 @@ namespace Spatialpy{
     struct EventNode;
 
     struct Particle{
-        Particle(ParticleSystem *sys, unsigned int id=0);
+        Particle(ParticleSystem *sys, unsigned int id=0, double x=0, double y=0, double z=0,
+                    int type=0, double nu=0.01, double mass=1,
+                    double rho=1, int solidTag=0);
         ParticleSystem *sys;
         unsigned int id;
         int type;

--- a/spatialpy/ssa_sdpd-c-simulation-engine/propensity_file_template.cpp
+++ b/spatialpy/ssa_sdpd-c-simulation-engine/propensity_file_template.cpp
@@ -83,22 +83,14 @@ namespace Spatialpy{
     //dsfmt_t dsfmt;
 
     void init_create_particle(ParticleSystem *sys, unsigned int id, double x, double y, double z, int type, double nu, double mass, double rho, int solidTag, int num_chem_species){
-        Particle *p  = new Particle(sys, id) ;
-        p->x[0] = x;
-        p->x[1] = y;
-        p->x[2] = z;
-        p->id = id;
-        p->type = type;
-        p->nu = nu;
-        p->mass = mass;
-        p->rho = rho;
-        p->solidTag = solidTag;
+        sys->particles.emplace_back(Particle(sys, id, x, y, z, type, nu, mass, rho,
+            solidTag));
+        Particle *this_particle = &sys->particles.back() ;
         if(num_chem_species > 0){
             for(int i=0;i<num_chem_species;i++){
-                p->C[i] = (double) input_u0[id*num_chem_species+i];
+                this_particle->C[i] = (double) input_u0[id*num_chem_species+i];
             }
         }
-        sys->add_particle(p);
     }
 
 
@@ -107,7 +99,6 @@ namespace Spatialpy{
         __INIT_PARTICLES__
         return id;
     }
-
 
     void applyBoundaryConditions(Particle* me, ParticleSystem* system){
     __BOUNDARY_CONDITIONS__

--- a/spatialpy/ssa_sdpd-c-simulation-engine/src/particle.cpp
+++ b/spatialpy/ssa_sdpd-c-simulation-engine/src/particle.cpp
@@ -60,14 +60,19 @@ namespace Spatialpy{
     	// x_index.push(me) ;
     	particles.push_back(*me) ;
     }
-    ParticleSystem::~ParticleSystem(){}
+    ParticleSystem::~ParticleSystem(){
+        particles.clear() ;
+    }
 
-    Particle::Particle(ParticleSystem *sys, unsigned int id):sys(sys), id(id){
-    	nu = 0.01;
-    	mass = 1;
-    	rho = 1;
-    	solidTag = 0;
-    	x[0] = x[1] = x[2] = 0.0;
+    Particle::Particle(ParticleSystem *sys, unsigned int id, 
+                        double xl, double yl, double zl, int type, double nu, 
+                        double mass, double rho, int solidTag) : 
+                        sys(sys), id(id), type(type), 
+                        nu(nu), mass(mass), rho(rho), solidTag(solidTag)
+    {
+    	x[0] = xl ;
+        x[1] = yl ;
+        x[2] = zl ;
     	v[0] = v[1] = v[2] = 0.0;
     	Q = (double*) calloc(sys->num_chem_species, sizeof(double));
     	C = (double*) calloc(sys->num_chem_species, sizeof(double));


### PR DESCRIPTION
set particle vector to be created in place rather than copied from pr…econstructed particles.  These preconstructed particles were not being deleted, and causing a memory leak. closes #149 